### PR TITLE
Add Matrix well-known endpoints

### DIFF
--- a/public/.well-known/matrix/client
+++ b/public/.well-known/matrix/client
@@ -1,0 +1,1 @@
+{ "m.homeserver": { "base_url": "https://matrix.nu31.space" } }

--- a/public/.well-known/matrix/server
+++ b/public/.well-known/matrix/server
@@ -1,0 +1,1 @@
+{ "m.server": "matrix.nu31.space:443" }


### PR DESCRIPTION
Adds Matrix discovery endpoints for `nu31.space` so clients and federated servers can resolve the homeserver at `https://matrix.nu31.space`.
