### PR TITLE
fix(rss): render inline markdown in content:encoded, add type to media:thumbnail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13922,7 +13922,6 @@
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
             "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"

--- a/server/core/content/publication.test.ts
+++ b/server/core/content/publication.test.ts
@@ -4,7 +4,52 @@ import {
     buildPublicArticleListItem,
     buildPublicArticleListResponse,
     buildPublicFeedEntry,
+    renderInlineMarkdown,
 } from './publication'
+
+describe('renderInlineMarkdown', () => {
+    it('converts **bold** to <strong>', () => {
+        expect(renderInlineMarkdown('**bold**')).toBe('<strong>bold</strong>')
+    })
+
+    it('converts __bold__ to <strong>', () => {
+        expect(renderInlineMarkdown('__bold__')).toBe('<strong>bold</strong>')
+    })
+
+    it('converts *italic* to <em>', () => {
+        expect(renderInlineMarkdown('*italic*')).toBe('<em>italic</em>')
+    })
+
+    it('converts _italic_ to <em>', () => {
+        expect(renderInlineMarkdown('_italic_')).toBe('<em>italic</em>')
+    })
+
+    it('converts `code` to <code>', () => {
+        expect(renderInlineMarkdown('`code`')).toBe('<code>code</code>')
+    })
+
+    it('converts [label](https://example.com) to <a href>', () => {
+        expect(renderInlineMarkdown('[label](https://example.com)')).toBe('<a href="https://example.com">label</a>')
+    })
+
+    it('strips unsafe link schemes — renders label only', () => {
+        expect(renderInlineMarkdown('[click](javascript:void0)')).toBe('click')
+        expect(renderInlineMarkdown('[click](data:text/html,hi)')).toBe('click')
+    })
+
+    it('HTML-escapes special chars before applying Markdown rules', () => {
+        expect(renderInlineMarkdown('a < b & c')).toBe('a &lt; b &amp; c')
+    })
+
+    it('leaves plain text unchanged beyond HTML escaping', () => {
+        expect(renderInlineMarkdown('no markup here')).toBe('no markup here')
+    })
+
+    it('handles mixed inline constructs in one string', () => {
+        const result = renderInlineMarkdown('**bold** and [link](https://x.com)')
+        expect(result).toBe('<strong>bold</strong> and <a href="https://x.com">link</a>')
+    })
+})
 
 describe('publication helpers', () => {
     const basePost = {
@@ -127,6 +172,21 @@ describe('publication helpers', () => {
         }, 'https://space.example')
 
         expect(article.publishedAt).toBe(article.updatedAt)
+    })
+
+    it('renders inline markdown in text blocks for RSS content:encoded', () => {
+        const entry = buildPublicFeedEntry({
+            slug: 'inline-test',
+            title: 'Inline Test',
+            rawMarkdown: '**bold** and *italic* and `code`',
+            status: 'published',
+            createdAt: new Date('2025-02-03T10:00:00.000Z'),
+            updatedAt: new Date('2025-02-04T15:30:00.000Z'),
+        }, 'https://space.example')
+
+        expect(entry.contentHtml).toContain('<strong>bold</strong>')
+        expect(entry.contentHtml).toContain('<em>italic</em>')
+        expect(entry.contentHtml).toContain('<code>code</code>')
     })
 
     it('builds feed entries with content HTML and media thumbnail', () => {

--- a/server/core/content/publication.ts
+++ b/server/core/content/publication.ts
@@ -9,6 +9,7 @@ import type {
 } from '~~/shared/types/content'
 import type { ContentBlock, TextBlock } from '~~/shared/types/content'
 import { parseMarkdownToBlocks } from './parse'
+import { marked } from 'marked'
 
 export interface BlogPostRecord {
     slug: string
@@ -52,11 +53,25 @@ function escapeHtml(value: string): string {
         .replaceAll('"', '&quot;')
 }
 
+// Custom renderer that strips links with non-http(s) schemes (javascript:, data:, etc.)
+// to prevent unsafe URLs from appearing in RSS output.
+const safeRenderer = new marked.Renderer()
+safeRenderer.link = ({ href, text }) => {
+    if (!/^https?:\/\//i.test(href)) return text
+    return `<a href="${href}">${text}</a>`
+}
+
+// Converts inline Markdown within a plain-text string to HTML using the marked library.
+// Applied only to text blocks in RSS output — the frontend renders inline Markdown via Vue components.
+export function renderInlineMarkdown(text: string): string {
+    return marked.parseInline(text, { renderer: safeRenderer }) as string
+}
+
 function renderBlocksToHtml(blocks: ContentBlock[]): string {
     return blocks.map(block => {
         switch (block.type) {
             case 'header': return `<h${block.size}>${escapeHtml(block.title)}</h${block.size}>`
-            case 'text': return `<p>${escapeHtml(block.content)}</p>`
+            case 'text': return `<p>${renderInlineMarkdown(block.content)}</p>`
             case 'image': return `<img src="${escapeHtml(block.imageUrl)}" alt="${escapeHtml(block.imageAlt || '')}" />`
             case 'code': return `<pre><code class="language-${escapeHtml(block.language)}">${escapeHtml(block.code)}</code></pre>`
             case 'list': {

--- a/server/core/content/rss.test.ts
+++ b/server/core/content/rss.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { renderRssFeed } from './rss'
+import { renderRssFeed, inferImageMimeType } from './rss'
 
 describe('rss feed renderer', () => {
     it('renders rss 2.0 xml with namespace, escaped values and items', () => {
@@ -32,9 +32,56 @@ describe('rss feed renderer', () => {
         expect(xml).toContain('<content:encoded><![CDATA[<p>Full article content.</p>]]></content:encoded>')
         expect(xml).toContain('<guid isPermaLink="false">https://space.example/blog/orbital-log</guid>')
         expect(xml).toContain('<category>space</category>')
-        expect(xml).toContain('<media:thumbnail url="https://space.example/media/station-cover.png" />')
+        expect(xml).toContain('<media:thumbnail url="https://space.example/media/station-cover.png" type="image/png" />')
         expect(xml).toContain('<pubDate>Fri, 31 Jan 2025 09:00:00 GMT</pubDate>')
         expect(xml).toContain('<lastBuildDate>Tue, 04 Feb 2025 15:30:00 GMT</lastBuildDate>')
+    })
+
+    it('includes type attribute on media:thumbnail with correct MIME type', () => {
+        const xml = renderRssFeed({
+            title: 'NU31 Blog',
+            feedUrl: 'https://space.example/rss.xml',
+            siteUrl: 'https://space.example',
+            description: 'Updates',
+            language: 'uk-UA',
+            lastBuildDate: '2025-02-04T15:30:00.000Z',
+            items: [{
+                id: 'https://space.example/blog/post',
+                title: 'Post',
+                url: 'https://space.example/blog/post',
+                description: '',
+                contentHtml: '',
+                publishedAt: '2025-01-31T09:00:00.000Z',
+                updatedAt: '2025-02-04T15:30:00.000Z',
+                categories: [],
+                mediaThumbnail: 'https://cdn.example.com/image.jpg',
+            }],
+        })
+
+        expect(xml).toContain('type="image/jpeg"')
+    })
+
+    it('omits media:thumbnail entirely when not set', () => {
+        const xml = renderRssFeed({
+            title: 'NU31 Blog',
+            feedUrl: 'https://space.example/rss.xml',
+            siteUrl: 'https://space.example',
+            description: 'Updates',
+            language: 'uk-UA',
+            lastBuildDate: '2025-02-04T15:30:00.000Z',
+            items: [{
+                id: 'https://space.example/blog/post',
+                title: 'Post',
+                url: 'https://space.example/blog/post',
+                description: '',
+                contentHtml: '',
+                publishedAt: '2025-01-31T09:00:00.000Z',
+                updatedAt: '2025-02-04T15:30:00.000Z',
+                categories: [],
+            }],
+        })
+
+        expect(xml).not.toContain('media:thumbnail')
     })
 
     it('omits optional tags when custom fields are empty', () => {
@@ -61,5 +108,22 @@ describe('rss feed renderer', () => {
         })
 
         expect(xml).not.toContain('media:thumbnail')
+    })
+})
+
+describe('inferImageMimeType', () => {
+    it.each([
+        ['https://example.com/img.jpg', 'image/jpeg'],
+        ['https://example.com/img.jpeg', 'image/jpeg'],
+        ['https://example.com/img.png', 'image/png'],
+        ['https://example.com/img.gif', 'image/gif'],
+        ['https://example.com/img.webp', 'image/webp'],
+        ['https://example.com/img.avif', 'image/avif'],
+        ['https://example.com/img.svg', 'image/svg+xml'],
+        ['https://cdn.discordapp.com/attachments/123/456/image', 'image/jpeg'],
+        ['https://example.com/img.bmp', 'image/jpeg'],
+        ['https://example.com/img.jpg?size=800', 'image/jpeg'],
+    ])('%s → %s', (url, expected) => {
+        expect(inferImageMimeType(url)).toBe(expected)
     })
 })

--- a/server/core/content/rss.ts
+++ b/server/core/content/rss.ts
@@ -3,6 +3,23 @@
 // All values are XML-escaped; content:encoded uses CDATA to allow raw HTML inside the envelope.
 import type { PublicFeedEntry } from './publication'
 
+const MIME_BY_EXTENSION: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    avif: 'image/avif',
+    svg: 'image/svg+xml',
+}
+
+// Infers an image MIME type from the URL file extension.
+// Defaults to image/jpeg for CDN URLs that have no extension (e.g. Discord CDN).
+export function inferImageMimeType(url: string): string {
+    const ext = url.split('?')[0].split('.').pop()?.toLowerCase() ?? ''
+    return MIME_BY_EXTENSION[ext] ?? 'image/jpeg'
+}
+
 export interface RssFeedDocument {
     title: string
     feedUrl: string
@@ -44,7 +61,7 @@ export function renderRssFeed(feed: RssFeedDocument): string {
             ? `<content:encoded><![CDATA[${item.contentHtml}]]></content:encoded>`
             : ''
         const mediaThumbnailXml = item.mediaThumbnail
-            ? `<media:thumbnail url="${escapeXml(item.mediaThumbnail)}" />`
+            ? `<media:thumbnail url="${escapeXml(item.mediaThumbnail)}" type="${inferImageMimeType(item.mediaThumbnail)}" />`
             : ''
 
         return [


### PR DESCRIPTION
## Summary

- `content:encoded` in RSS feed now renders inline Markdown as HTML instead of passing raw `**bold**`, `[link](url)` syntax as literal text. Uses `marked.parseInline` with a safe renderer that strips non-http(s) link schemes.
- `<media:thumbnail>` now includes a `type` attribute (e.g. `type="image/jpeg"`) inferred from the cover image URL extension, so hackerspace.news correctly identifies the attachment as an image and shows it in the card image slot.

## Test plan

- [ ] Check RSS feed on hackerspace.news — cover image appears on post cards
- [ ] Check Space Detail page on hackerspace.news — post body renders as formatted HTML, not raw Markdown
