### PR TITLE
Add events section with Gancio integration to homepage

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -114,6 +114,15 @@
                 </MainButton>
             </div>
 
+            <div class="mb-20">
+                <h2 class="text-3xl font-bold mb-8 text-center text-accent-primary">
+                    Наші події
+                </h2>
+                <ClientOnly>
+                    <gancio-events baseurl="https://events.nu31.space" show_recurrent="true" maxlength="10" sidebar="false" theme="light" />
+                </ClientOnly>
+            </div>
+
             <div v-if="mediaPosts && mediaPosts.length > 0" class="mb-20">
                 <h2 class="text-3xl font-bold mb-8 text-center text-accent-primary">
                     Медіа про нас
@@ -194,10 +203,19 @@
 </template>
 
 <script setup lang="ts">
-import { definePageMeta, navigateTo } from '#imports'
+import { definePageMeta, navigateTo, useHead } from '#imports'
 import { onMounted } from 'vue'
 import { trackEvent } from '~~/app/utils/track'
 import { useFetch } from '#imports'
+
+useHead({
+    script: [
+        {
+            src: 'https://events.nu31.space/gancio-events.es.js',
+            type: 'module',
+        },
+    ],
+})
 import { useUser } from '~/composables/useUser'
 import { useElectricityStatus } from '~/composables/useElectricityStatus'
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -119,7 +119,7 @@
                     Наші події
                 </h2>
                 <ClientOnly>
-                    <gancio-events baseurl="https://events.nu31.space" show_recurrent="true" maxlength="10" sidebar="false" theme="light" />
+                    <gancio-events baseurl="https://events.nu31.space" show_recurrent="true" maxlength="10" sidebar="false" :theme="theme" />
                 </ClientOnly>
             </div>
 
@@ -218,6 +218,7 @@ useHead({
 })
 import { useUser } from '~/composables/useUser'
 import { useElectricityStatus } from '~/composables/useElectricityStatus'
+import { useTheme } from '~/composables/useTheme'
 
 definePageMeta({
     layout: 'void',
@@ -234,6 +235,8 @@ const {
     badgeLabel: electricityBadgeLabel,
     fetchStatus: fetchElectricityStatus,
 } = useElectricityStatus()
+
+const { theme } = useTheme()
 
 const { data: mediaPosts } = await useFetch<Array<{
     id: string

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,6 +26,13 @@ export default defineNuxtConfig({
     },
     vite: {
         plugins: [tailwindcss()],
+        vue: {
+            template: {
+                compilerOptions: {
+                    isCustomElement: (tag) => tag === 'gancio-events',
+                },
+            },
+        },
     },
     css: ['~/assets/css/main.css'],
     app: {


### PR DESCRIPTION
## Summary
This PR adds an events section to the homepage that displays upcoming events from an external Gancio events service.

## Key Changes
- **Homepage UI**: Added a new "Наші події" (Our Events) section to the index page displaying events from `https://events.nu31.space`
  - Configured to show up to 10 events with recurrent events enabled
  - Uses light theme and hides sidebar
  - Wrapped in `ClientOnly` component for client-side rendering

- **Script Loading**: Added dynamic loading of the Gancio events web component script (`gancio-events.es.js`) via `useHead()` in the page setup

- **Vue Configuration**: Updated Nuxt config to recognize `gancio-events` as a custom HTML element, allowing Vue to properly handle the third-party web component without treating it as an unknown element

## Implementation Details
- The events section is positioned between the main CTA buttons and the media section
- Uses consistent styling with other sections (mb-20 spacing, text-3xl bold heading with accent-primary color)
- The web component is loaded as an ES module for better compatibility

https://claude.ai/code/session_019tdAFWHZ9Y71hQJbShCLi2