### PR TITLE
Fix events widget not rendering: wrong script type and import order

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -207,18 +207,17 @@ import { definePageMeta, navigateTo, useHead } from '#imports'
 import { onMounted } from 'vue'
 import { trackEvent } from '~~/app/utils/track'
 import { useFetch } from '#imports'
+import { useUser } from '~/composables/useUser'
+import { useElectricityStatus } from '~/composables/useElectricityStatus'
+import { useTheme } from '~/composables/useTheme'
 
 useHead({
     script: [
         {
             src: 'https://events.nu31.space/gancio-events.es.js',
-            type: 'module',
         },
     ],
 })
-import { useUser } from '~/composables/useUser'
-import { useElectricityStatus } from '~/composables/useElectricityStatus'
-import { useTheme } from '~/composables/useTheme'
 
 definePageMeta({
     layout: 'void',


### PR DESCRIPTION
Removed type: 'module' from the gancio-events script — the embed code uses a plain <script src>, and ES module loading semantics (deferred, CORS) were preventing the custom element from registering. Also moved all imports to the top of the script block where they belong.

https://claude.ai/code/session_019tdAFWHZ9Y71hQJbShCLi2